### PR TITLE
Improved play synchronization

### DIFF
--- a/client/player.go
+++ b/client/player.go
@@ -7,17 +7,19 @@ import (
 	"os"
 	"path"
 	"time"
+	"github.com/zklapow/SpotifySync/lib"
 )
 
 type SpotifyPlayer struct {
-	Conf      *Config
-	Session   *spotify.Session
-	portaudio *portAudio
-	exit      chan bool
-	events    *Events
+	Conf       *Config
+	Session    *spotify.Session
+	portaudio  *portAudio
+	exit       chan bool
+	events     *Events
+	timeSyncer *lib.TimeSyncer
 }
 
-func newSpotifyPlayer(conf *Config) *SpotifyPlayer {
+func newSpotifyPlayer(conf *Config, timeSyncer *lib.TimeSyncer) *SpotifyPlayer {
 	prog := path.Base(os.Args[0])
 	appKey, err := ioutil.ReadFile(conf.AppKeyPath)
 	if err != nil {
@@ -57,6 +59,7 @@ func newSpotifyPlayer(conf *Config) *SpotifyPlayer {
 		portaudio: pa,
 		exit:      make(chan bool),
 		events:    newEvents(),
+		timeSyncer: timeSyncer,
 	}
 }
 

--- a/client/pubnub.go
+++ b/client/pubnub.go
@@ -12,9 +12,7 @@ type PubNubEventDispatcher struct {
 	pubnub *messaging.Pubnub
 }
 
-func newPubNubEventDispatcher(events *Events, conf *Config) *PubNubEventDispatcher {
-	pubnub := messaging.NewPubnub(conf.PublishKey, conf.SubscribeKey, conf.SecretKey, "", false, "")
-
+func newPubNubEventDispatcher(events *Events, pubnub *messaging.Pubnub, conf *Config) *PubNubEventDispatcher {
 	return &PubNubEventDispatcher{conf: conf, events: events, pubnub: pubnub}
 }
 

--- a/client/pubnub.go
+++ b/client/pubnub.go
@@ -4,16 +4,23 @@ import (
 	"encoding/json"
 	"github.com/pubnub/go/messaging"
 	"github.com/zklapow/SpotifySync/lib"
+	"time"
 )
 
 type PubNubEventDispatcher struct {
-	conf   *Config
-	events *Events
-	pubnub *messaging.Pubnub
+	conf       *Config
+	events     *Events
+	pubnub     *messaging.Pubnub
+	timeSyncer *lib.TimeSyncer
 }
 
 func newPubNubEventDispatcher(events *Events, pubnub *messaging.Pubnub, conf *Config) *PubNubEventDispatcher {
-	return &PubNubEventDispatcher{conf: conf, events: events, pubnub: pubnub}
+	return &PubNubEventDispatcher{
+		conf: conf,
+		events: events,
+		pubnub: pubnub,
+		timeSyncer: lib.StartTimeSync(pubnub),
+	}
 }
 
 func (dispatch *PubNubEventDispatcher) Run() {
@@ -83,7 +90,20 @@ func (dispatch *PubNubEventDispatcher) handleCommand(command map[string]interfac
 		}
 		logger.Debugf("Enqueuing link %v", track)
 
-		dispatch.events.Play(track.(string))
+		execAt, ok := command["execAt"]
+		if !ok {
+			dispatch.events.Play(track.(string))
+			return
+		} else {
+			execAtTime := time.Unix(0, int64(execAt.(float64)))
+			timeUntilExec := execAtTime.Sub(dispatch.timeSyncer.SyncedTime())
+
+			logger.Debugf("Waiting %v to play new track", timeUntilExec)
+			time.AfterFunc(timeUntilExec, func() {
+				dispatch.events.Play(track.(string))
+			})
+		}
+
 	}
 }
 

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -1,0 +1,9 @@
+package lib
+
+import "github.com/op/go-logging"
+
+var logger = logging.MustGetLogger("spotifysync")
+
+var format = logging.MustStringFormatter(
+	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+)

--- a/lib/pubnubutils.go
+++ b/lib/pubnubutils.go
@@ -1,0 +1,13 @@
+package lib
+
+import "encoding/json"
+
+func jsonToArray(data []byte) ([]interface{}, error) {
+	var arr []interface{}
+	if err := json.Unmarshal(data, &arr); err != nil {
+		logger.Errorf("Failed to decode JSON from pubnub: %v", err)
+		return nil, err
+	}
+
+	return arr, nil
+}

--- a/lib/sync.go
+++ b/lib/sync.go
@@ -1,1 +1,119 @@
 package lib
+
+import (
+	"github.com/pubnub/go/messaging"
+	"sync"
+	"time"
+)
+
+var syncInterval = time.Minute * 10
+
+type TimeSyncer struct {
+	pubnub *messaging.Pubnub
+
+	start time.Time
+	timetoken time.Time
+
+	synced bool
+	syncResults chan bool
+
+	sync.RWMutex
+}
+
+var instance *TimeSyncer
+var once sync.Once
+
+func StartTimeSync(pubnub *messaging.Pubnub) *TimeSyncer {
+	once.Do(func() {
+		instance = &TimeSyncer{
+			pubnub: pubnub,
+			syncResults: make(chan bool, 1),
+		}
+
+		instance.syncTime()
+	})
+
+	return instance
+}
+
+func (syncer *TimeSyncer) AwaitSynced() bool {
+	if syncer.synced {
+		return true
+	}
+
+	syncResult := <- syncer.syncResults
+
+	if syncResult {
+		syncer.synced = true
+	}
+
+	return syncResult
+}
+
+func (syncer *TimeSyncer) SyncedTime() time.Time {
+	syncer.RLock()
+	timeChange := time.Now().Sub(syncer.start)
+	clientTime := syncer.timetoken.Add(timeChange)
+	syncer.RUnlock()
+
+	return clientTime
+}
+
+func (syncer *TimeSyncer) syncTime() {
+	startTime := time.Now()
+
+	successChannel := make(chan []byte)
+	errorChannel := make(chan []byte)
+
+	go func() {
+		syncer.syncResults <- syncer.handleTimeToken(successChannel, errorChannel, startTime)
+	}()
+	go syncer.pubnub.GetTime(successChannel, errorChannel)
+
+	time.AfterFunc(syncInterval, syncer.syncTime) // Sync time every syncInterval to prevent clock drift
+}
+
+func (syncer *TimeSyncer) handleTimeToken(successChannel, errorChannel chan []byte, startTime time.Time) bool {
+	for {
+		select {
+		case success, ok := <-successChannel:
+			if !ok {
+				break
+			}
+			if string(success) != "[]" {
+				logger.Debugf("Successfully got timetoken: %v", string(success))
+			}
+
+			results, err := jsonToArray(success)
+			if err != nil || len(results) == 0 {
+				return false
+			}
+
+			syncer.updateSyncState(int64(results[0].(float64)), startTime)
+			return true
+		case failure, ok := <-errorChannel:
+			if !ok {
+				break
+			}
+			if string(failure) != "[]" {
+				logger.Errorf("Failed to get timetoken: %v", string(failure))
+			}
+
+			return false
+		case <- time.After(time.Duration(messaging.GetNonSubscribeTimeout()) * time.Second):
+			logger.Errorf("Timeout out waiting for time token!")
+			return false
+		}
+	}
+
+	return false
+}
+
+func (syncer *TimeSyncer) updateSyncState(timetoken int64, startTime time.Time) {
+	syncer.Lock()
+	durationToken := time.Duration(timetoken/10000) * time.Millisecond
+
+	syncer.timetoken = time.Unix(0, durationToken.Nanoseconds())
+	syncer.start = startTime
+	syncer.Unlock()
+}

--- a/server/main.go
+++ b/server/main.go
@@ -16,14 +16,15 @@ import (
 )
 
 type Config struct {
-	SlackToken   string
-	PublishKey   string
-	SubscribeKey string
-	SecretKey    string
-	AppKeyPath   string
-	Username     string
-	Password     string
-	Channel      string
+	SlackToken     string
+	PublishKey     string
+	SubscribeKey   string
+	SecretKey      string
+	AppKeyPath     string
+	Username       string
+	Password       string
+	Channel        string
+	LatencyDelayMs int64
 }
 
 var logger = logging.MustGetLogger("syncserver")

--- a/server/pubnub.go
+++ b/server/pubnub.go
@@ -9,8 +9,7 @@ type PubnubPublisher struct {
 	pubnub *messaging.Pubnub
 }
 
-func newPubnubPublisher(conf *Config) *PubnubPublisher {
-	pubnub := messaging.NewPubnub(conf.PublishKey, conf.SubscribeKey, conf.SecretKey, "", false, "")
+func newPubnubPublisher(conf *Config, pubnub *messaging.Pubnub) *PubnubPublisher {
 	return &PubnubPublisher{pubnub: pubnub}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -21,19 +21,21 @@ func init() {
 }
 
 type Server struct {
-	conf      *Config
-	publisher *PubnubPublisher
-	queue     *lib.PlayQueue
-	session   *spotify.Session
-	state     *PlayState
+	conf       *Config
+	publisher  *PubnubPublisher
+	queue      *lib.PlayQueue
+	session    *spotify.Session
+	state      *PlayState
+	timeSyncer *lib.TimeSyncer
 }
 
-func newServer(conf *Config) *Server {
+func newServer(conf *Config, publisher *PubnubPublisher, timeSyncer *lib.TimeSyncer) *Server {
 	return &Server{
 		conf:      conf,
-		publisher: newPubnubPublisher(conf),
+		publisher: publisher,
 		queue:     lib.NewPlayQueue(),
 		session:   createSpotifySession(conf),
+		timeSyncer: timeSyncer,
 	}
 }
 


### PR DESCRIPTION
Rather than just relying on messages arriving at the same time, we now have an actual sync algorithm.

On start (and once every subsequent 10 minutes) we do clock synchronization. This consists of:
1. Record start of clock sync in system time
2. Get pubnub network time
3. Calculate current network time by taking doing `pubnubNetworkTime + (syncStart - currentTime)`

We can repeat step 3 whenever we need to get the current synced time.

The second part of this PR causes commands to execute at a specific (synced) time. We do this by sending and `execAt` timestamp. When the client receives a command with an `execAt` it calculates the difference between its current `SyncedTime()` and the `execAt` and schedules a timer to run the command at that time.

This adds some latency to command execution (because `execAt` must be buffered to be greater than the max client latency) currently this buffer is fixed, but eventually it should be adaptive based on reported client latencies (which we now know because of our synced clock!)

Because I know you care so much about this @jenhuang 
